### PR TITLE
Fix imports to use correct vcs location

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -10,20 +10,48 @@ pipeline {
     }
     stage('Build binary - armhf') {
       steps {
-        node(label: 'arm64') {
-          cleanWs(cleanWhenAborted: true, cleanWhenFailure: true, cleanWhenNotBuilt: true, cleanWhenSuccess: true, cleanWhenUnstable: true, deleteDirs: true)
-          unstash 'source'
-          sh '''export architecture="armhf"
-                build-binary.sh'''
-          stash(includes: '*.gz,*.bz2,*.xz,*.deb,*.dsc,*.changes,*.buildinfo,lintian.txt', name: 'build-armhf')
-          cleanWs(cleanWhenAborted: true, cleanWhenFailure: true, cleanWhenNotBuilt: true, cleanWhenSuccess: true, cleanWhenUnstable: true, deleteDirs: true)
-        }
+        parallel(
+          "Build binary - armhf": {
+            node(label: 'arm64') {
+              cleanWs(cleanWhenAborted: true, cleanWhenFailure: true, cleanWhenNotBuilt: true, cleanWhenSuccess: true, cleanWhenUnstable: true, deleteDirs: true)
+              unstash 'source'
+              sh '''export architecture="armhf"
+build-binary.sh'''
+              stash(includes: '*.gz,*.bz2,*.xz,*.deb,*.dsc,*.changes,*.buildinfo,lintian.txt', name: 'build-armhf')
+              cleanWs(cleanWhenAborted: true, cleanWhenFailure: true, cleanWhenNotBuilt: true, cleanWhenSuccess: true, cleanWhenUnstable: true, deleteDirs: true)
+            }
+
+
+          },
+          "Build binary - arm64": {
+            node(label: 'arm64') {
+              cleanWs(cleanWhenAborted: true, cleanWhenFailure: true, cleanWhenNotBuilt: true, cleanWhenSuccess: true, cleanWhenUnstable: true, deleteDirs: true)
+              unstash 'source'
+              sh '''export architecture="arm64"
+    build-binary.sh'''
+              stash(includes: '*.gz,*.bz2,*.xz,*.deb,*.dsc,*.changes,*.buildinfo,lintian.txt', name: 'build-arm64')
+              cleanWs(cleanWhenAborted: true, cleanWhenFailure: true, cleanWhenNotBuilt: true, cleanWhenSuccess: true, cleanWhenUnstable: true, deleteDirs: true)
+            }
+          },
+          "Build binary - amd64": {
+            node(label: 'amd64') {
+              cleanWs(cleanWhenAborted: true, cleanWhenFailure: true, cleanWhenNotBuilt: true, cleanWhenSuccess: true, cleanWhenUnstable: true, deleteDirs: true)
+              unstash 'source'
+              sh '''export architecture="amd64"
+    build-binary.sh'''
+              stash(includes: '*.gz,*.bz2,*.xz,*.deb,*.dsc,*.changes,*.buildinfo,lintian.txt', name: 'build-amd64')
+              cleanWs(cleanWhenAborted: true, cleanWhenFailure: true, cleanWhenNotBuilt: true, cleanWhenSuccess: true, cleanWhenUnstable: true, deleteDirs: true)
+            }
+          }
+        )
       }
     }
     stage('Results') {
       steps {
         cleanWs(cleanWhenAborted: true, cleanWhenFailure: true, cleanWhenNotBuilt: true, cleanWhenSuccess: true, cleanWhenUnstable: true, deleteDirs: true)
         unstash 'build-armhf'
+        unstash 'build-arm64'
+        unstash 'build-amd64'
         archiveArtifacts(artifacts: '*.gz,*.bz2,*.xz,*.deb,*.dsc,*.changes,*.buildinfo', fingerprint: true, onlyIfSuccessful: true)
         sh '''/usr/bin/build-repo.sh'''
       }

--- a/cmd/ciborium-ui/main.go
+++ b/cmd/ciborium-ui/main.go
@@ -70,7 +70,7 @@ func init() {
 }
 
 func goSource() string {
-	return filepath.Join("launchpad.net", "ciborium")
+	return filepath.Join("github.com", "ubports", "ciborium")
 }
 
 func main() {

--- a/cmd/ciborium-ui/main.go
+++ b/cmd/ciborium-ui/main.go
@@ -28,8 +28,8 @@ import (
 
 	"log"
 
-	"launchpad.net/ciborium/qml.v1"
-	"launchpad.net/ciborium/udisks2"
+	"github.com/ubports/ciborium/qml.v1"
+	"github.com/ubports/ciborium/udisks2"
 	"launchpad.net/go-dbus/v1"
 	"launchpad.net/go-xdg/v0"
 )

--- a/cmd/ciborium/main.go
+++ b/cmd/ciborium/main.go
@@ -30,9 +30,9 @@ import (
 	"syscall"
 	"time"
 
-	"launchpad.net/ciborium/gettext"
-	"launchpad.net/ciborium/notifications"
-	"launchpad.net/ciborium/udisks2"
+	"github.com/ubports/ciborium/gettext"
+	"github.com/ubports/ciborium/notifications"
+	"github.com/ubports/ciborium/udisks2"
 	"launchpad.net/go-dbus/v1"
 )
 

--- a/debian/rules
+++ b/debian/rules
@@ -3,7 +3,7 @@
 
 export DH_OPTIONS
 export DH_GOLANG_INSTALL_ALL=1
-export DH_GOPKG := launchpad.net/ciborium
+export DH_GOPKG := github.com/ubports/ciborium
 
 %:
 	dh $@ \

--- a/qml.v1/bridge.go
+++ b/qml.v1/bridge.go
@@ -1,8 +1,8 @@
 package qml
 
-// #cgo linux,amd64 CPPFLAGS: -I./cpp -isystem /usr/include/x86_64-linux-gnu/qt5/QtCore/5.9.3 -isystem /usr/include/x86_64-linux-gnu/qt5/QtCore/5.9.3/QtCore -isystem /usr/include/x86_64-linux-gnu/qt5/QtCore/5.9.3
-// #cgo linux,arm CPPFLAGS: -I./cpp -isystem /usr/include/arm-linux-gnueabihf/qt5/QtCore/5.9.3 -isystem /usr/include/arm-linux-gnueabihf/qt5/QtCore/5.9.3/QtCore -isystem /usr/include/arm-linux-gnueabihf/qt5/QtCore/5.9.3
-// #cgo linux,arm64 CPPFLAGS: -I./cpp -isystem /usr/include/aarch64-linux-gnu/qt5/QtCore/5.9.3 -isystem /usr/include/aarch64-linux-gnu/qt5/QtCore/5.9.3/QtCore -isystem /usr/include/aarch64-linux-gnu/qt5/QtCore/5.9.3
+// #cgo linux,amd64 CPPFLAGS: -I./cpp -isystem /usr/include/x86_64-linux-gnu/qt5/QtCore/5.9.5 -isystem /usr/include/x86_64-linux-gnu/qt5/QtCore/5.9.5/QtCore -isystem /usr/include/x86_64-linux-gnu/qt5/QtCore/5.9.5
+// #cgo linux,arm CPPFLAGS: -I./cpp -isystem /usr/include/arm-linux-gnueabihf/qt5/QtCore/5.9.5 -isystem /usr/include/arm-linux-gnueabihf/qt5/QtCore/5.9.5/QtCore -isystem /usr/include/arm-linux-gnueabihf/qt5/QtCore/5.9.5
+// #cgo linux,arm64 CPPFLAGS: -I./cpp -isystem /usr/include/aarch64-linux-gnu/qt5/QtCore/5.9.5 -isystem /usr/include/aarch64-linux-gnu/qt5/QtCore/5.9.5/QtCore -isystem /usr/include/aarch64-linux-gnu/qt5/QtCore/5.9.5
 // #cgo CXXFLAGS: -std=c++0x -pedantic-errors -Wall -fno-strict-aliasing
 // #cgo LDFLAGS: -lstdc++
 // #cgo pkg-config: Qt5Core Qt5Widgets Qt5Quick

--- a/qml.v1/bridge.go
+++ b/qml.v1/bridge.go
@@ -1,6 +1,8 @@
 package qml
 
-// #cgo CPPFLAGS: -I./cpp -isystem /usr/include/arm-linux-gnueabihf/qt5/QtCore/5.9.3 -isystem /usr/include/arm-linux-gnueabihf/qt5/QtCore/5.9.3/QtCore -isystem /usr/include/arm-linux-gnueabihf/qt5/QtCore/5.9.3
+// #cgo linux,amd64 CPPFLAGS: -I./cpp -isystem /usr/include/x86_64-linux-gnu/qt5/QtCore/5.9.3 -isystem /usr/include/x86_64-linux-gnu/qt5/QtCore/5.9.3/QtCore -isystem /usr/include/x86_64-linux-gnu/qt5/QtCore/5.9.3
+// #cgo linux,arm CPPFLAGS: -I./cpp -isystem /usr/include/arm-linux-gnueabihf/qt5/QtCore/5.9.3 -isystem /usr/include/arm-linux-gnueabihf/qt5/QtCore/5.9.3/QtCore -isystem /usr/include/arm-linux-gnueabihf/qt5/QtCore/5.9.3
+// #cgo linux,arm64 CPPFLAGS: -I./cpp -isystem /usr/include/arm-linux-gnueabihf/qt5/QtCore/5.9.3 -isystem /usr/include/arm-linux-gnueabihf/qt5/QtCore/5.9.3/QtCore -isystem /usr/include/arm-linux-gnueabihf/qt5/QtCore/5.9.3
 // #cgo CXXFLAGS: -std=c++0x -pedantic-errors -Wall -fno-strict-aliasing
 // #cgo LDFLAGS: -lstdc++
 // #cgo pkg-config: Qt5Core Qt5Widgets Qt5Quick

--- a/qml.v1/bridge.go
+++ b/qml.v1/bridge.go
@@ -21,7 +21,7 @@ import (
 	"sync/atomic"
 	"unsafe"
 
-	"launchpad.net/ciborium/qml.v1/cdata"
+	"github.com/ubports/ciborium/qml.v1/cdata"
 )
 
 var (

--- a/qml.v1/bridge.go
+++ b/qml.v1/bridge.go
@@ -2,7 +2,7 @@ package qml
 
 // #cgo linux,amd64 CPPFLAGS: -I./cpp -isystem /usr/include/x86_64-linux-gnu/qt5/QtCore/5.9.3 -isystem /usr/include/x86_64-linux-gnu/qt5/QtCore/5.9.3/QtCore -isystem /usr/include/x86_64-linux-gnu/qt5/QtCore/5.9.3
 // #cgo linux,arm CPPFLAGS: -I./cpp -isystem /usr/include/arm-linux-gnueabihf/qt5/QtCore/5.9.3 -isystem /usr/include/arm-linux-gnueabihf/qt5/QtCore/5.9.3/QtCore -isystem /usr/include/arm-linux-gnueabihf/qt5/QtCore/5.9.3
-// #cgo linux,arm64 CPPFLAGS: -I./cpp -isystem /usr/include/arm-linux-gnueabihf/qt5/QtCore/5.9.3 -isystem /usr/include/arm-linux-gnueabihf/qt5/QtCore/5.9.3/QtCore -isystem /usr/include/arm-linux-gnueabihf/qt5/QtCore/5.9.3
+// #cgo linux,arm64 CPPFLAGS: -I./cpp -isystem /usr/include/aarch64-linux-gnu/qt5/QtCore/5.9.3 -isystem /usr/include/aarch64-linux-gnu/qt5/QtCore/5.9.3/QtCore -isystem /usr/include/aarch64-linux-gnu/qt5/QtCore/5.9.3
 // #cgo CXXFLAGS: -std=c++0x -pedantic-errors -Wall -fno-strict-aliasing
 // #cgo LDFLAGS: -lstdc++
 // #cgo pkg-config: Qt5Core Qt5Widgets Qt5Quick
@@ -25,12 +25,12 @@ import (
 )
 
 var (
-	guiFunc      = make(chan func())
-	guiDone      = make(chan struct{})
-	guiLock      = 0
-	guiMainRef   uintptr
-	guiPaintRef  uintptr
-	guiIdleRun   int32
+	guiFunc     = make(chan func())
+	guiDone     = make(chan struct{})
+	guiLock     = 0
+	guiMainRef  uintptr
+	guiPaintRef uintptr
+	guiIdleRun  int32
 
 	initialized int32
 )

--- a/qml.v1/cpptest/cpptest.go
+++ b/qml.v1/cpptest/cpptest.go
@@ -13,11 +13,11 @@ import "C"
 import (
 	"unsafe"
 
-	"launchpad.net/ciborium/qml.v1"
+	"github.com/ubports/ciborium/qml.v1"
 )
 
 func NewTestType(engine *qml.Engine) qml.Object {
-	var obj qml.Object 
+	var obj qml.Object
 	qml.RunMain(func() {
 		addr := C.newTestType()
 		obj = qml.CommonOf(addr, engine)

--- a/qml.v1/doc.go
+++ b/qml.v1/doc.go
@@ -114,7 +114,7 @@
 //            Init: func(p *Person, obj qml.Object) { p.Name = "<none>" },
 //    }})
 //
-// With this logic in place, QML code can create new instances of Person by itself:     
+// With this logic in place, QML code can create new instances of Person by itself:
 //
 //    import QtQuick 2.0
 //    import GoExtensions 1.0
@@ -128,7 +128,7 @@
 //
 //
 // Lowercasing of names
-// 
+//
 // Independently from the mechanism used to publish a Go value to QML code, its methods
 // and fields are available to QML logic as methods and properties of the
 // respective QML object representing it. As required by QML, though, the Go
@@ -177,7 +177,7 @@
 // a Paint method such as:
 //
 //    func (p *Person) Paint(painter *qml.Painter) {
-//            // ... OpenGL calls with the launchpad.net/ciborium/qml.v1/gl/<VERSION> package ...
+//            // ... OpenGL calls with the github.com/ubports/ciborium/qml.v1/gl/<VERSION> package ...
 //    }
 //
 // A simple example is available at:
@@ -190,7 +190,7 @@
 // Resource files (qml code, images, etc) may be packed into the Go qml application
 // binary to simplify its handling and distribution. This is done with the genqrc tool:
 //
-//   http://launchpad.net/ciborium/qml.v1/cmd/genqrc#usage
+//   http://github.com/ubports/ciborium/qml.v1/cmd/genqrc#usage
 //
 // The following blog post provides more details:
 //

--- a/qml.v1/qml.go
+++ b/qml.v1/qml.go
@@ -9,7 +9,7 @@ import "C"
 import (
 	"errors"
 	"fmt"
-	"launchpad.net/ciborium/qml.v1/gl/glbase"
+	"github.com/ubports/ciborium/qml.v1/gl/glbase"
 	"image"
 	"image/color"
 	"io"
@@ -1097,9 +1097,9 @@ func LoadResources(r *Resources) {
 	} else if len(r.bdata) > 0 {
 		base = *(*unsafe.Pointer)(unsafe.Pointer(&r.bdata))
 	}
-	tree := (*C.char)(unsafe.Pointer(uintptr(base)+uintptr(r.treeOffset)))
-	name := (*C.char)(unsafe.Pointer(uintptr(base)+uintptr(r.nameOffset)))
-	data := (*C.char)(unsafe.Pointer(uintptr(base)+uintptr(r.dataOffset)))
+	tree := (*C.char)(unsafe.Pointer(uintptr(base) + uintptr(r.treeOffset)))
+	name := (*C.char)(unsafe.Pointer(uintptr(base) + uintptr(r.nameOffset)))
+	data := (*C.char)(unsafe.Pointer(uintptr(base) + uintptr(r.dataOffset)))
 	C.registerResourceData(C.int(r.version), tree, name, data)
 }
 
@@ -1111,8 +1111,8 @@ func UnloadResources(r *Resources) {
 	} else if len(r.bdata) > 0 {
 		base = *(*unsafe.Pointer)(unsafe.Pointer(&r.bdata))
 	}
-	tree := (*C.char)(unsafe.Pointer(uintptr(base)+uintptr(r.treeOffset)))
-	name := (*C.char)(unsafe.Pointer(uintptr(base)+uintptr(r.nameOffset)))
-	data := (*C.char)(unsafe.Pointer(uintptr(base)+uintptr(r.dataOffset)))
+	tree := (*C.char)(unsafe.Pointer(uintptr(base) + uintptr(r.treeOffset)))
+	name := (*C.char)(unsafe.Pointer(uintptr(base) + uintptr(r.nameOffset)))
+	data := (*C.char)(unsafe.Pointer(uintptr(base) + uintptr(r.dataOffset)))
 	C.unregisterResourceData(C.int(r.version), tree, name, data)
 }

--- a/qml.v1/testing.go
+++ b/qml.v1/testing.go
@@ -7,7 +7,7 @@ import "C"
 import (
 	"bytes"
 	"encoding/binary"
-	"launchpad.net/ciborium/qml.v1/cdata"
+	"github.com/ubports/ciborium/qml.v1/cdata"
 	"reflect"
 	"unsafe"
 )


### PR DESCRIPTION
Updates to not use the old launchpad url imports and it seems gofmt has fixed some style issues :-)

This depends on https://github.com/ubports/ciborium/pull/5 landing first