### PR TITLE
Use arch specific paths for CPPFLAGS

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -10,20 +10,48 @@ pipeline {
     }
     stage('Build binary - armhf') {
       steps {
-        node(label: 'arm64') {
-          cleanWs(cleanWhenAborted: true, cleanWhenFailure: true, cleanWhenNotBuilt: true, cleanWhenSuccess: true, cleanWhenUnstable: true, deleteDirs: true)
-          unstash 'source'
-          sh '''export architecture="armhf"
-                build-binary.sh'''
-          stash(includes: '*.gz,*.bz2,*.xz,*.deb,*.dsc,*.changes,*.buildinfo,lintian.txt', name: 'build-armhf')
-          cleanWs(cleanWhenAborted: true, cleanWhenFailure: true, cleanWhenNotBuilt: true, cleanWhenSuccess: true, cleanWhenUnstable: true, deleteDirs: true)
-        }
+        parallel(
+          "Build binary - armhf": {
+            node(label: 'arm64') {
+              cleanWs(cleanWhenAborted: true, cleanWhenFailure: true, cleanWhenNotBuilt: true, cleanWhenSuccess: true, cleanWhenUnstable: true, deleteDirs: true)
+              unstash 'source'
+              sh '''export architecture="armhf"
+build-binary.sh'''
+              stash(includes: '*.gz,*.bz2,*.xz,*.deb,*.dsc,*.changes,*.buildinfo,lintian.txt', name: 'build-armhf')
+              cleanWs(cleanWhenAborted: true, cleanWhenFailure: true, cleanWhenNotBuilt: true, cleanWhenSuccess: true, cleanWhenUnstable: true, deleteDirs: true)
+            }
+
+
+          },
+          "Build binary - arm64": {
+            node(label: 'arm64') {
+              cleanWs(cleanWhenAborted: true, cleanWhenFailure: true, cleanWhenNotBuilt: true, cleanWhenSuccess: true, cleanWhenUnstable: true, deleteDirs: true)
+              unstash 'source'
+              sh '''export architecture="arm64"
+    build-binary.sh'''
+              stash(includes: '*.gz,*.bz2,*.xz,*.deb,*.dsc,*.changes,*.buildinfo,lintian.txt', name: 'build-arm64')
+              cleanWs(cleanWhenAborted: true, cleanWhenFailure: true, cleanWhenNotBuilt: true, cleanWhenSuccess: true, cleanWhenUnstable: true, deleteDirs: true)
+            }
+          },
+          "Build binary - amd64": {
+            node(label: 'amd64') {
+              cleanWs(cleanWhenAborted: true, cleanWhenFailure: true, cleanWhenNotBuilt: true, cleanWhenSuccess: true, cleanWhenUnstable: true, deleteDirs: true)
+              unstash 'source'
+              sh '''export architecture="amd64"
+    build-binary.sh'''
+              stash(includes: '*.gz,*.bz2,*.xz,*.deb,*.dsc,*.changes,*.buildinfo,lintian.txt', name: 'build-amd64')
+              cleanWs(cleanWhenAborted: true, cleanWhenFailure: true, cleanWhenNotBuilt: true, cleanWhenSuccess: true, cleanWhenUnstable: true, deleteDirs: true)
+            }
+          }
+        )
       }
     }
     stage('Results') {
       steps {
         cleanWs(cleanWhenAborted: true, cleanWhenFailure: true, cleanWhenNotBuilt: true, cleanWhenSuccess: true, cleanWhenUnstable: true, deleteDirs: true)
         unstash 'build-armhf'
+        unstash 'build-arm64'
+        unstash 'build-amd64'
         archiveArtifacts(artifacts: '*.gz,*.bz2,*.xz,*.deb,*.dsc,*.changes,*.buildinfo', fingerprint: true, onlyIfSuccessful: true)
         sh '''/usr/bin/build-repo.sh'''
       }

--- a/qml.v1/bridge.go
+++ b/qml.v1/bridge.go
@@ -1,8 +1,8 @@
 package qml
 
-// #cgo linux,amd64 CPPFLAGS: -I./cpp -isystem /usr/include/x86_64-linux-gnu/qt5/QtCore/5.9.3 -isystem /usr/include/x86_64-linux-gnu/qt5/QtCore/5.9.3/QtCore -isystem /usr/include/x86_64-linux-gnu/qt5/QtCore/5.9.3
-// #cgo linux,arm CPPFLAGS: -I./cpp -isystem /usr/include/arm-linux-gnueabihf/qt5/QtCore/5.9.3 -isystem /usr/include/arm-linux-gnueabihf/qt5/QtCore/5.9.3/QtCore -isystem /usr/include/arm-linux-gnueabihf/qt5/QtCore/5.9.3
-// #cgo linux,arm64 CPPFLAGS: -I./cpp -isystem /usr/include/aarch64-linux-gnu/qt5/QtCore/5.9.3 -isystem /usr/include/aarch64-linux-gnu/qt5/QtCore/5.9.3/QtCore -isystem /usr/include/aarch64-linux-gnu/qt5/QtCore/5.9.3
+// #cgo linux,amd64 CPPFLAGS: -I./cpp -isystem /usr/include/x86_64-linux-gnu/qt5/QtCore/5.9.5 -isystem /usr/include/x86_64-linux-gnu/qt5/QtCore/5.9.5/QtCore -isystem /usr/include/x86_64-linux-gnu/qt5/QtCore/5.9.5
+// #cgo linux,arm CPPFLAGS: -I./cpp -isystem /usr/include/arm-linux-gnueabihf/qt5/QtCore/5.9.5 -isystem /usr/include/arm-linux-gnueabihf/qt5/QtCore/5.9.5/QtCore -isystem /usr/include/arm-linux-gnueabihf/qt5/QtCore/5.9.5
+// #cgo linux,arm64 CPPFLAGS: -I./cpp -isystem /usr/include/aarch64-linux-gnu/qt5/QtCore/5.9.5 -isystem /usr/include/aarch64-linux-gnu/qt5/QtCore/5.9.5/QtCore -isystem /usr/include/aarch64-linux-gnu/qt5/QtCore/5.9.5
 // #cgo CXXFLAGS: -std=c++0x -pedantic-errors -Wall -fno-strict-aliasing
 // #cgo LDFLAGS: -lstdc++
 // #cgo pkg-config: Qt5Core Qt5Widgets Qt5Quick

--- a/qml.v1/bridge.go
+++ b/qml.v1/bridge.go
@@ -1,6 +1,8 @@
 package qml
 
-// #cgo CPPFLAGS: -I./cpp -isystem /usr/include/arm-linux-gnueabihf/qt5/QtCore/5.9.3 -isystem /usr/include/arm-linux-gnueabihf/qt5/QtCore/5.9.3/QtCore -isystem /usr/include/arm-linux-gnueabihf/qt5/QtCore/5.9.3
+// #cgo linux,amd64 CPPFLAGS: -I./cpp -isystem /usr/include/x86_64-linux-gnu/qt5/QtCore/5.9.3 -isystem /usr/include/x86_64-linux-gnu/qt5/QtCore/5.9.3/QtCore -isystem /usr/include/x86_64-linux-gnu/qt5/QtCore/5.9.3
+// #cgo linux,arm CPPFLAGS: -I./cpp -isystem /usr/include/arm-linux-gnueabihf/qt5/QtCore/5.9.3 -isystem /usr/include/arm-linux-gnueabihf/qt5/QtCore/5.9.3/QtCore -isystem /usr/include/arm-linux-gnueabihf/qt5/QtCore/5.9.3
+// #cgo linux,arm64 CPPFLAGS: -I./cpp -isystem /usr/include/arm-linux-gnueabihf/qt5/QtCore/5.9.3 -isystem /usr/include/arm-linux-gnueabihf/qt5/QtCore/5.9.3/QtCore -isystem /usr/include/arm-linux-gnueabihf/qt5/QtCore/5.9.3
 // #cgo CXXFLAGS: -std=c++0x -pedantic-errors -Wall -fno-strict-aliasing
 // #cgo LDFLAGS: -lstdc++
 // #cgo pkg-config: Qt5Core Qt5Widgets Qt5Quick

--- a/qml.v1/bridge.go
+++ b/qml.v1/bridge.go
@@ -2,7 +2,7 @@ package qml
 
 // #cgo linux,amd64 CPPFLAGS: -I./cpp -isystem /usr/include/x86_64-linux-gnu/qt5/QtCore/5.9.3 -isystem /usr/include/x86_64-linux-gnu/qt5/QtCore/5.9.3/QtCore -isystem /usr/include/x86_64-linux-gnu/qt5/QtCore/5.9.3
 // #cgo linux,arm CPPFLAGS: -I./cpp -isystem /usr/include/arm-linux-gnueabihf/qt5/QtCore/5.9.3 -isystem /usr/include/arm-linux-gnueabihf/qt5/QtCore/5.9.3/QtCore -isystem /usr/include/arm-linux-gnueabihf/qt5/QtCore/5.9.3
-// #cgo linux,arm64 CPPFLAGS: -I./cpp -isystem /usr/include/arm-linux-gnueabihf/qt5/QtCore/5.9.3 -isystem /usr/include/arm-linux-gnueabihf/qt5/QtCore/5.9.3/QtCore -isystem /usr/include/arm-linux-gnueabihf/qt5/QtCore/5.9.3
+// #cgo linux,arm64 CPPFLAGS: -I./cpp -isystem /usr/include/aarch64-linux-gnu/qt5/QtCore/5.9.3 -isystem /usr/include/aarch64-linux-gnu/qt5/QtCore/5.9.3/QtCore -isystem /usr/include/aarch64-linux-gnu/qt5/QtCore/5.9.3
 // #cgo CXXFLAGS: -std=c++0x -pedantic-errors -Wall -fno-strict-aliasing
 // #cgo LDFLAGS: -lstdc++
 // #cgo pkg-config: Qt5Core Qt5Widgets Qt5Quick
@@ -25,12 +25,12 @@ import (
 )
 
 var (
-	guiFunc      = make(chan func())
-	guiDone      = make(chan struct{})
-	guiLock      = 0
-	guiMainRef   uintptr
-	guiPaintRef  uintptr
-	guiIdleRun   int32
+	guiFunc     = make(chan func())
+	guiDone     = make(chan struct{})
+	guiLock     = 0
+	guiMainRef  uintptr
+	guiPaintRef uintptr
+	guiIdleRun  int32
 
 	initialized int32
 )


### PR DESCRIPTION
This allows us to build for all supported architectures although we will have to manually update the paths on each Qt change :-( but not sure what else we can do about it.

This also resolves #1 