### PR TITLE
Fix Safe Remove dialog not appearing

### DIFF
--- a/share/ciborium/qml/components/SafeRemoval.qml
+++ b/share/ciborium/qml/components/SafeRemoval.qml
@@ -109,7 +109,7 @@ Dialog {
                 target: safeRemovalDlg
                 explicit: true
                 title: i18n.tr("Unmount Error");
-                text: i18n.tr("The device could not be unmounted because is busy");;
+                text: i18n.tr("The device could not be unmounted because is busy");
             }
             PropertyChanges {
                 target: okButton


### PR DESCRIPTION
Fixes ubports/ubuntu-touch#755 by allowing the Safe Remove dialog to appear